### PR TITLE
deploy: Update secret and deployment machinery

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,33 @@
 [![PkgGoDev](https://pkg.go.dev/badge/mod/foxygo.at/jcdc)](https://pkg.go.dev/mod/foxygo.at/jcdc)
 [![Slack chat](https://img.shields.io/badge/slack-gophers-795679?logo=slack)](https://gophers.slack.com/messages/foxygoat)
 
-Kubernetes deployment webhook and server for externally triggered
-deployments, e.g. GitHub actions.
+JCDC is a web server providing a webhook for externally triggered
+commands, e.g. a deployment triggered by successful GitHub actions
+workflow. It is intended to be used with
+[kubecfg](https://github.com/bitnami/kubecfg) provided in its image and
+Kubernetes deployments.
 
 ### Development
 
 - Pre-requisites: [go](https://golang.org), [golangci-lint](https://github.com/golangci/golangci-lint/releases/tag/v1.33.2), GNU make
 - Build with `make`
 - View build options with `make help`
+
+### Deployment
+
+Kubernetes deployment targets for deploying to clusters created with
+[k3sinst](https://github.com/foxygoat/k3sinst) are provided in the
+Makefile where LABEL becomes a subdirectory of `deployment/`. Run
+
+    make deploy-LABEL
+
+and follow instructions.
+
+Retrieve the secret API key with
+
+    make show-secret
+
+Test your deployment with
+
+    curl https://<HOSTNAME>/version
+    curl https://<HOSTNAME>/run -d '{"apiKey": <SECRET>, "command": "echo hello world" }'

--- a/deployment/goat/overlay.jsonnet
+++ b/deployment/goat/overlay.jsonnet
@@ -1,0 +1,7 @@
+{
+  manifest+: [$.sealedSecret],
+  config+: {
+    hostname: 'jcdc.jul.run',
+  },
+  sealedSecret:: import 'secret.json',
+}

--- a/deployment/goat/secret.json
+++ b/deployment/goat/secret.json
@@ -1,0 +1,21 @@
+{
+  "kind": "SealedSecret",
+  "apiVersion": "bitnami.com/v1alpha1",
+  "metadata": {
+    "name": "jcdc",
+    "namespace": "jcdc",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "template": {
+      "metadata": {
+        "name": "jcdc",
+        "namespace": "jcdc",
+        "creationTimestamp": null
+      }
+    },
+    "encryptedData": {
+      "apikey": "AgAwZfM8nlEU4JnPTeWRgY+HoIM+1S8YbNcCQhocwzNOyR0h+3vCJ0DjLyn3SiCIkUqPpE5SUGvgQwVZLMrfc+y5+vOpW+u/ziwOOeYg9f098ueOckVAHzQ8slaFhsZYE1LGlbjlp+hBd6akS6bMQ6faHBHLGICofJFgcaH53/GeDuFoi40S2FDFxlNq4f8vevQBA3jQaJ3DDZFMdnP17BvXi/RiDjHmFBa7O4p3HezLDYtv/73Ae6tciTvYtmgz1o7uV6lGi1peg/dA8SXm4d55bFMhxNJ0wEIbfk5e00u9LL9sjt7zhHl24ChSPW1s3dPapLsAqmSBykuc/Kj5gC11BCxovM6hxIJq00h07dXA1c5VdweiEuV9e/2NmRMXuvTrSL+YjbU+JZKF9wgj1pe8fdOk07kq59dOQEzsQGgnOC4EReewxPOFw8NF4F27iczoO3WIXLyaUV/cKyyP59BfhEARarZ9eqEDC65IntrifPgTrW+07oAfnLb09yx/RqOTAH7S29E8mS/1EBj7xnUTv3HRVqJQkwQfZEg51P+ZvfrfBQmNPOmk29652F1Lj6UPFAvaN4GnTvrGggqJ4C26qvTQFIIixaTaZS/DFinkF6aQ3v5JAJPMDf1k0ETKF/AljavCjk9feTBi5BF+foiRmsg2JTlsf7yF1I5NrNyQcHdYHn7N0baHezqDWNoL7aFp6JhpGzCXT2/KjWyF8IOfguLR7bdeNOmzpb/7CfNyaS7AeYJLQNhWRE6gjQcm5BSR5tX7mTYGdO7stEqgodIi"
+    }
+  }
+}

--- a/deployment/jcdc.jsonnet
+++ b/deployment/jcdc.jsonnet
@@ -3,8 +3,8 @@
     hostname: null,
     docker_tag: 'latest',
   },
-  configure(hostname=null, docker_tag=null)::
-    self {
+  configure(overlay={}, hostname=null, docker_tag=null)::
+    self + overlay + {
       config+: std.prune({
         hostname: hostname,
         docker_tag: docker_tag,
@@ -15,7 +15,6 @@
     $.namespace,
     $.service,
     $.deployment,
-    $.secret,
     if $.config.hostname != null then $.ingress,
   ],
   namespace:: {
@@ -69,7 +68,7 @@
               ports: [{ containerPort: 8080, name: 'http', protocol: 'TCP' }],
               env: [{
                 name: 'JCDC_API_KEY',
-                valueFrom: { secretKeyRef: { key: 'key', name: 'apikey' } },
+                valueFrom: { secretKeyRef: { key: 'apikey', name: 'jcdc' } },
               }],
             },
           ],
@@ -116,17 +115,6 @@
           secretName: 'jcdc-https-cert',
         },
       ],
-    },
-  },
-  secret:: {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      namespace: 'jcdc',
-      name: 'apikey',
-    },
-    data: {
-      key: std.base64('secret'),  // ⚠️ needs to be overridden on a per-site basis
     },
   },
 }


### PR DESCRIPTION
Update secret and deployment machinery and add new make targets. `make
deploy-LABEL` generates sealed Secret used as API key and scaffolds new
deployment. Update `deployment/LABEL/overlay.jsonnet` with custom hostname
and run `make deploy-LABEL` again. Add `make show-secret` target to show
"unsealed" secret for external usage of JCDC API.


Add goat specific deployment config generated and applied with

   	make deploy-goat