### PR TITLE
deploy: Improve deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.15-alpine AS builder
 WORKDIR /src
 RUN apk add git make
 
-# Build master of kubecfg for unreleased 32 bit changes
-RUN git clone https://github.com/bitnami/kubecfg
+RUN git clone -b open-via-importer https://github.com/camh-/kubecfg
 RUN make -C kubecfg
 
 ARG COMMIT_SHA

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ COLOUR_GREEN  = $(shell tput setaf 2 2>/dev/null)
 COLOUR_WHITE  = $(shell tput setaf 7 2>/dev/null)
 
 help:
-	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9%_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 $(O):
 	@mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet  
 show-deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet  ## Show k8s manifests that would be deployed
 	kubecfg show $(TLA_ARGS) deployment/main.jsonnet
 
+diff-deploy-%:  ## Show diff of k8s manifests between files and deployed
+	kubecfg diff $(TLA_ARGS) deployment/main.jsonnet
+
+undeploy-%:  ## Delete deployment
+	kubecfg delete $(TLA_ARGS) deployment/main.jsonnet
+
 deployment/%:
 	mkdir $@
 

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ docker-test: docker-build
 
 # --- Deployment -------------------------------------------------------------------
 TLA_ARGS = \
-	$(if $(DEPLOY_TAG), --tla-str docker_tag=$(DEPLOY_TAG)) \
 	$(if $(DEPLOY_HOSTNAME), --tla-str hostname=$(DEPLOY_HOSTNAME)) \
+	--tla-str docker_tag=$(DOCKER_TAG) \
 	--tla-code-file overlay=deployment/$*/overlay.jsonnet
 
 deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet  ## Generate and deploy k8s manifests

--- a/deployment/jcdc.jsonnet
+++ b/deployment/jcdc.jsonnet
@@ -14,6 +14,9 @@
   manifest: [
     $.namespace,
     $.service,
+    $.serviceAccount,
+    $.clusterRole,
+    $.clusterRoleBinding,
     $.deployment,
     if $.config.hostname != null then $.ingress,
   ],
@@ -38,6 +41,43 @@
       },
     },
   },
+  serviceAccount:: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: 'jcdc',
+      namespace: 'jcdc',
+    },
+  },
+  clusterRole:: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRole',
+    metadata: {
+      name: 'jcdc',
+    },
+    rules: [{
+      apiGroups: ['*'],
+      resources: ['*'],
+      verbs: ['*'],
+    }],
+  },
+  clusterRoleBinding:: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRoleBinding',
+    metadata: {
+      name: 'jcdc',
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'jcdc',
+    },
+    subjects: [{
+      kind: 'ServiceAccount',
+      name: 'jcdc',
+      namespace: 'jcdc',
+    }],
+  },
   deployment:: {
     apiVersion: 'apps/v1',
     kind: 'Deployment',
@@ -61,6 +101,8 @@
           },
         },
         spec: {
+          serviceAccountName: 'jcdc',
+          automountServiceAccountToken: true,
           containers: [
             {
               image: 'foxygoat/jcdc:%s' % $.config.docker_tag,

--- a/deployment/jcdc.jsonnet
+++ b/deployment/jcdc.jsonnet
@@ -105,7 +105,9 @@
           automountServiceAccountToken: true,
           containers: [
             {
+              local policy(tag) = if tag == 'latest' || std.startsWith(tag, 'pr') then 'Always' else 'IfNotPresent',
               image: 'foxygoat/jcdc:%s' % $.config.docker_tag,
+              imagePullPolicy: policy($.config.docker_tag),
               name: 'jcdc',
               ports: [{ containerPort: 8080, name: 'http', protocol: 'TCP' }],
               env: [{


### PR DESCRIPTION
Update kubecfg version to camh's fork[1], as the bitnami/kubecfg version
doesn't support remote sources which we need for jcdc, e.g.:

   kubecfg show https://github.com/foxygoat/foxtrot/raw/master/deployment/main.jsonnet

Add k8s service account and cluster role (binding).

Sneak in minor Makefile changes:

- better help regexp
- updated DOCKER_TAG variable
- undeploy diff-deploy targets

[1]: https://github.com/camh-/kubecfg/commit/7f47c390f509d8be9e6e3adf60c9e372c6a2589b