### PR TITLE
jcdc: Return http 400 on failed command

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func Run(w http.ResponseWriter, r *http.Request) error {
 	cmd := exec.Command("/bin/sh", "-c", p.Command)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(w, "error: %s\n", err)
+		return errs.Errorf("%v: %v\n%s", httpe.ErrBadRequest, err, out)
 	}
 	_, _ = w.Write(out)
 	return nil

--- a/main_test.go
+++ b/main_test.go
@@ -101,11 +101,11 @@ func (s *AppTestSuite) TestRunErrMissingCommand() {
 	t := s.T()
 	payload := fmt.Sprintf(`{
 		"apiKey":  "%s",
-		"command": "exit 13"
+		"command": "printf hello && exit 13"
 	}`, s.apiKey)
 	body, status := httpPost(t, s.baseURL+"/run", payload)
-	require.Equal(t, http.StatusOK, status)
-	require.Equal(t, "error: exit status 13\n", body)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "Bad Request: exit status 13\nhello\n", body)
 }
 
 func (s *AppTestSuite) TestVersion() {


### PR DESCRIPTION
Return http status 400 on failed if command execution returns an error -
typically with non-zero exit status.